### PR TITLE
Arreglar el redirect despues del logout

### DIFF
--- a/src/components/LogoutButton.jsx
+++ b/src/components/LogoutButton.jsx
@@ -5,7 +5,15 @@ export function LogoutButton() {
   const { logout } = useAuth0();
 
   return (
-    <Button onClick={logout} sx={{ color: "white" }}>
+    <Button
+      onClick={() =>
+        logout({
+          returnTo:
+            process.env.REACT_APP_LOGOUT_CALLBACK || "http://:localhost:3000/",
+        })
+      }
+      sx={{ color: "white" }}
+    >
       Logout
     </Button>
   );


### PR DESCRIPTION
## #43 

## 🏁 Motivacion

El boton en prod seguir redirigiendo a localhost:3000

## 🔍 Prueba de que funciona

usamos la option `returnTo` para poder decirle a donde redirigir despues del logout. La idea es que en prod agreguemos un .env o una variable de ambiente que se llame REACT_APP_LOGOUT_CALLBACK y que tenga como valor la ruta absoluta de la home. @nicolas-alv3 


## ✅ Checklist

- [ ] Cree tests para los cambios realizados.
- [x] Testie de forma local estos cambios.
